### PR TITLE
Remove duplicated manage home using deprecated syntax

### DIFF
--- a/cookbooks/habitat_workstation/recipes/default.rb
+++ b/cookbooks/habitat_workstation/recipes/default.rb
@@ -37,7 +37,6 @@ user 'chef' do
   manage_home true
   home '/home/chef'
   shell '/bin/bash'
-  supports :manage_home => true
   password '$1$seaspong$/UREL79gaEZJRXoYPaKnE.'
   action :create
 end


### PR DESCRIPTION
You have a manage_home in here twice; once using the new syntax, and once using the old deprecated syntax 😁 